### PR TITLE
Add docker config and get pytests running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM python:3.7.4
 COPY . /app
 WORKDIR "/app"
 
-RUN python3.7 -m pip install -r requirements.txt
+RUN python3.7 -m pip install -r requirements.dev.txt
 
 RUN python3.7 setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7.4
+
+COPY . /app
+WORKDIR "/app"
+
+RUN python3.7 -m pip install -r requirements.txt
+
+RUN python3.7 setup.py develop

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ First, install Docker.  Then:
 
     docker-compose build
 
-Test:
+Test the executable (quick):
 
     docker-compose run cubetls /usr/local/bin/cubetl -h
+
+Run pytest tests (quite slow .. 20-30 minutes?):
+
+    docker-compose run cubetls pytest -v
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -42,10 +42,22 @@ While CubETL is in development no *pip* packages are provided, and it should be 
 using `python setup.py develop`. Using a virtualenv or docker instance is recommended.
 
     git clone https://github.com/jjmontesl/cubetl.git
+    cd cubetl
 
+    # Using a virtualenv is usually recommended:
+    python3 -m venv env
+    . env/bin/activate
 
-Install
--------
+    # Install dependencies (this command is for Ubuntu)
+    sudo apt-get install python3-dev libxml2-dev libxslt1-dev zlib1g-dev
+
+    # Install CubETL (in development mode, so you can make changes to the source)
+    python setup.py develop
+    
+    # Test
+    cubetl -h
+
+**Install on docker**
 
 First, install Docker.  Then:
 
@@ -55,7 +67,7 @@ Test the executable (quick):
 
     docker-compose run cubetls /usr/local/bin/cubetl -h
 
-Run pytest tests (quite slow .. 20-30 minutes?):
+Run pytest tests (this is currently quite slow: 20-30 minutes):
 
     docker-compose run cubetls pytest -v
 

--- a/README.md
+++ b/README.md
@@ -39,24 +39,21 @@ Download / Install
 ------------------
 
 While CubETL is in development no *pip* packages are provided, and it should be installed
-using `python setup.py develop`. Using a virtualenv is recommended.
+using `python setup.py develop`. Using a virtualenv or docker instance is recommended.
 
     git clone https://github.com/jjmontesl/cubetl.git
-    cd cubetl
 
-    # Using a virtualenv is usually recommended:
-    python3 -m venv env
-    . env/bin/activate
 
-    # Install dependencies
-    sudo apt-get install python3-dev libxml2-dev libxslt1-dev zlib1g-dev
+Install
+-------
 
-    # Install CubETL
-    python setup.py develop
+First, install Docker.  Then:
+
+    docker-compose build
 
 Test:
 
-    cubetl -h
+    docker-compose run cubetl_container /usr/local/bin/cubetl -h
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ First, install Docker.  Then:
 
 Test:
 
-    docker-compose run cubetl_container /usr/local/bin/cubetl -h
+    docker-compose run cubetls /usr/local/bin/cubetl -h
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Run pytest tests (quite slow .. 20-30 minutes?):
 
     docker-compose run cubetls pytest -v
 
+Run one pytest:
+
+    docker-compose run cubetls python -m pytest -v -k test_config_new
+
+
 Usage
 -----
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  # "cubetl service" = "cubetls"
+  cubetls:
+    build: .
+    environment:
+      - PYTHONDONTWRITEBYTECODE=true
+      - PYTHONPATH=.
+    volumes:
+      # mount current directory so that changes in files are reflected
+      # in the running envirinment
+      - .:/app

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+pytest==5.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ incf.countryutils==1.0
 incf.dai==0.7
 lxml==4.2.5
 odict==1.6.2
-pkg-resources==0.0.0
+# This didn't work:
+# pkg-resources==0.0.0
 psutil==5.4.8
 Pygments==2.3.1
 pyparsing==2.1.1

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,9 +15,7 @@ class TestExamples(object):
 
     @pytest.fixture
     def dir_examples(self):
-        ret = os.path.dirname(os.path.abspath(__file__)) + "/../examples"
-        print("dir_examples = %s" % ret)
-        return ret
+        return os.path.dirname(os.path.abspath(__file__)) + "/../examples"
 
     def test_config_new(self, ctx, tmpdir):
         # Include other configuration files
@@ -40,7 +38,7 @@ class TestExamples(object):
         raise NotImplemented("Test not implemented")
         #result = ctx.run("process")
 
-    @pytest.mark.skip(reason="incf.countryutils doesn't work in Python 3.")
+    # @pytest.mark.skip(reason="incf.countryutils doesn't work in Python 3.")
     def test_loganalyzer(self, ctx, dir_examples):
         # Include other configuration files
         os.chdir(dir_examples + "/loganalyzer")
@@ -54,7 +52,6 @@ class TestExamples(object):
         ctx.include("estat_eip.py")
         # Launch process
         result = ctx.run("estat.process")
-
 
     def test_pcaxis(self, ctx, dir_examples):
         # Include other configuration files

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -38,7 +38,7 @@ class TestExamples(object):
         raise NotImplemented("Test not implemented")
         #result = ctx.run("process")
 
-    # @pytest.mark.skip(reason="incf.countryutils doesn't work in Python 3.")
+    @pytest.mark.skip(reason="incf.countryutils doesn't work in Python 3.")
     def test_loganalyzer(self, ctx, dir_examples):
         # Include other configuration files
         os.chdir(dir_examples + "/loganalyzer")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,12 +10,14 @@ class TestExamples(object):
     @pytest.fixture(scope='function')
     def ctx(self):
         # Create Cubetl context
-        ctx = cubetl.cubetl(debug=False, quiet=True)
+        ctx = cubetl.cubetl(debug=True, quiet=False)
         return ctx
 
     @pytest.fixture
     def dir_examples(self):
-        return "/home/jjmontes/git/cubetl/examples"
+        ret = os.path.dirname(os.path.abspath(__file__)) + "/../examples"
+        print("dir_examples = %s" % ret)
+        return ret
 
     def test_config_new(self, ctx, tmpdir):
         # Include other configuration files
@@ -30,6 +32,7 @@ class TestExamples(object):
         # Launch process
         result = ctx.run("directorylist.process")
 
+    @pytest.mark.skip(reason="Test not implemented.")
     def test_db2olap(self, ctx, dir_examples):
         # Include other configuration files
         os.chdir(dir_examples + "/sql2olap")
@@ -37,6 +40,7 @@ class TestExamples(object):
         raise NotImplemented("Test not implemented")
         #result = ctx.run("process")
 
+    @pytest.mark.skip(reason="incf.countryutils doesn't work in Python 3.")
     def test_loganalyzer(self, ctx, dir_examples):
         # Include other configuration files
         os.chdir(dir_examples + "/loganalyzer")
@@ -50,6 +54,7 @@ class TestExamples(object):
         ctx.include("estat_eip.py")
         # Launch process
         result = ctx.run("estat.process")
+
 
     def test_pcaxis(self, ctx, dir_examples):
         # Include other configuration files


### PR DESCRIPTION
I could not find in the docs which Python is supported (although a closed issue says 3.5+). I wish to use Python 3.X (not sure which yet).

I also develop on OS X, which doesn't have apt-get. To do that, the quickest way seemed to be to put it in Docker with fixed versions, so I could build and run quickly.
