### PR TITLE
Replace deprecated logger.warn with logger.warning.

### DIFF
--- a/cubetl/core/components.py
+++ b/cubetl/core/components.py
@@ -71,7 +71,7 @@ class Components():
         # TODO: Count references and finalize in an adequate order!!!
 
         if (not self.is_initialized(comp)):
-            logger.warn("Finalized a non initialized component: %s" % comp)
+            logger.warning("Finalized a non initialized component: %s" % comp)
         if (not self.is_finalized(comp)):
             logger.debug("Finalizing %s" % comp)
             self.component_desc(comp).finalized = True
@@ -87,5 +87,5 @@ class Components():
     def cleanup(self):
         for comp_desc in self.components.values():
             if (not comp_desc.finalized):
-                logger.warn("Unfinalized component %s" % comp_desc.comp)
+                logger.warning("Unfinalized component %s" % comp_desc.comp)
 

--- a/cubetl/fs/__init__.py
+++ b/cubetl/fs/__init__.py
@@ -119,7 +119,7 @@ class FileInfo(Node):
             m[self.prefix + 'size'] = stat.st_size
             m[self.prefix + 'mtime'] = stat.st_mtime
         except IOError as e:
-            logger.warn("Could not stat file: %s", path)
+            logger.warning("Could not stat file: %s", path)
             m[self.prefix + 'size'] = None
             m[self.prefix + 'mtime'] = None
 

--- a/cubetl/http/__init__.py
+++ b/cubetl/http/__init__.py
@@ -81,7 +81,7 @@ class HttpReader(FileReader):
                 response = urllib2.urlopen(req)
                 html = response.read()
             except Exception as e:
-                logger.warn("Could not retrieve HTTP document (attempt %d/%d): %s " % (attempt_count, self.attempts, e))
+                logger.warning("Could not retrieve HTTP document (attempt %d/%d): %s " % (attempt_count, self.attempts, e))
 
         # Encoding
         """

--- a/cubetl/olap/sql.py
+++ b/cubetl/olap/sql.py
@@ -278,7 +278,7 @@ class TableMapper(Component):
 
         if (len(pk_mappings) > 1):
             #raise Exception("%s has multiple primary keys mapped: %s" % (self, pk_mappings))
-            logger.warn("%s has multiple primary keys mapped: %s (ignoring)" % (self, pk_mappings))
+            logger.warning("%s has multiple primary keys mapped: %s (ignoring)" % (self, pk_mappings))
             return None
         elif (len(pk_mappings) == 1):
             return pk_mappings[0]
@@ -419,7 +419,7 @@ class TableMapper(Component):
                     if v1 != v2:
                         # Give warning just one time for each field
                         if (mapping.sqlcolumn not in self._lookup_changed_fields):
-                            logger.warn("%s looked up an entity which exists with different attributes (field=%s, existing_value=%r, tried_value=%r) (reported only once per field)" % (self, mapping.sqlcolumn, v1, v2))
+                            logger.warning("%s looked up an entity which exists with different attributes (field=%s, existing_value=%r, tried_value=%r) (reported only once per field)" % (self, mapping.sqlcolumn, v1, v2))
                             self._lookup_changed_fields.append(mapping.sqlcolumn)
 
         pk = self.pk(ctx)

--- a/cubetl/olap/sqlschema.py
+++ b/cubetl/olap/sqlschema.py
@@ -249,12 +249,12 @@ class SQLToOLAP(Node):
                     if related_fact_name == sqltable.name:
                         # Reference to self
                         # TODO: This does not account for circular dependencies across other entities
-                        logger.warn("Ignoring foreign key reference to self: %s", dbcol.name)
+                        logger.warning("Ignoring foreign key reference to self: %s", dbcol.name)
                         continue
 
                     related_fact = facts.get(related_fact_name, None)
                     if related_fact is None:
-                        logger.warn("Ignoring foreign key reference from %s.%s to not available entity: %s", dbcol.sqltable.name, dbcol.name, related_fact_name)
+                        logger.warning("Ignoring foreign key reference from %s.%s to not available entity: %s", dbcol.sqltable.name, dbcol.name, related_fact_name)
                         continue
 
                     # Create dimension attribute
@@ -354,12 +354,12 @@ class SQLToOLAP(Node):
 
             # Ignore table if more than one primary key was found
             if key_count > 1:
-                logger.warn("Multiple primary key found in table %s (not supported, ignoring table)", sqltable.name)
+                logger.warning("Multiple primary key found in table %s (not supported, ignoring table)", sqltable.name)
                 continue
 
             # Ignore table if it contains no primary key
             if key_count == 0:
-                logger.warn("No primary key found in table %s (not supported, ignoring table)", sqltable.name)
+                logger.warning("No primary key found in table %s (not supported, ignoring table)", sqltable.name)
                 continue
 
             # Define fact

--- a/cubetl/pcaxis/__init__.py
+++ b/cubetl/pcaxis/__init__.py
@@ -62,7 +62,7 @@ class PCAxisIterator(Node):
             try:
                 container['value'] = value
             except ValueError as e:
-                logger.warn("PCAxisIterator could not parse value: %r (cell: %s)", value, container)
+                logger.warning("PCAxisIterator could not parse value: %r (cell: %s)", value, container)
                 value = None
 
             m.update(container)

--- a/cubetl/script/__init__.py
+++ b/cubetl/script/__init__.py
@@ -145,7 +145,7 @@ class Eval(Node):
                         m[evalitem["name"]] = data[evalitem["name"]]
                     else:
                         if (not "default" in evalitem):
-                            logging.warn("Mapping with no value and no default: %s" % evalitem)
+                            logging.warning("Mapping with no value and no default: %s" % evalitem)
                         #m[evalitem["name"]] = None
 
                 if ("default" in evalitem):

--- a/cubetl/sql/schemaimport.py
+++ b/cubetl/sql/schemaimport.py
@@ -120,7 +120,7 @@ class DBToSQL(Node):
                     foreign_sqlcolumn = ctx.get(foreign_sqlcolumn_name, fail=False)
 
                     if not foreign_sqlcolumn and (True):
-                        logger.warn("Skipped foreign key %s in table %s, as foreign key column (%s.%s) was not found.", dbcol.name, dbtable.name, list(dbcol.foreign_keys)[0].column.table.name, list(dbcol.foreign_keys)[0].column.name)
+                        logger.warning("Skipped foreign key %s in table %s, as foreign key column (%s.%s) was not found.", dbcol.name, dbtable.name, list(dbcol.foreign_keys)[0].column.table.name, list(dbcol.foreign_keys)[0].column.name)
                         continue
 
                     column = cubetl.sql.sql.SQLColumnFK(name=dbcol.name, label=functions.labelify(dbcol.name),

--- a/cubetl/sql/sql.py
+++ b/cubetl/sql/sql.py
@@ -344,7 +344,7 @@ class SQLTable(Component):
                             if (not isinstance(v2, str)): v2 = str(v2)
                         if (v1 != v2):
                             if (c.name not in self._lookup_changed_fields):
-                                logger.warn("%s updating an entity that exists with different attributes, overwriting (field=%s, existing_value=%s, tried_value=%s)" % (self, c.name, v1, v2))
+                                logger.warning("%s updating an entity that exists with different attributes, overwriting (field=%s, existing_value=%s, tried_value=%s)" % (self, c.name, v1, v2))
                                 #self._lookup_changed_fields.append(c["name"])
 
                 # Update the row
@@ -369,7 +369,7 @@ class SQLTable(Component):
                 if (column.type == "String") and (not isinstance(row[column.name], str)):
                     self._unicode_errors = self._unicode_errors + 1
                     if (ctx.debug):
-                        logger.warn("Unicode column %r received non-unicode string: %r " % (column.name, row[column.name]))
+                        logger.warning("Unicode column %r received non-unicode string: %r " % (column.name, row[column.name]))
 
         return row
 

--- a/cubetl/text/__init__.py
+++ b/cubetl/text/__init__.py
@@ -87,7 +87,7 @@ class RegExp(Node):
                 raise ETLException("Failed to match regular expresion %s on value: %s" % (self.regexp, data))
             else:
                 if self.errors == RegExp.ERRORS_WARN:
-                    logger.warn("Failed to match regular expresion %s on value: %s", self.regexp, data)
+                    logger.warning("Failed to match regular expresion %s on value: %s", self.regexp, data)
                 return
 
         matches = matches[0]


### PR DESCRIPTION
Addresses issue #3.

I ran

```
for file in `git grep -l '.warn('`; do
  echo $file
  cat $file | perl -ne 's/.warn\(/.warning\(/g; print' > foo
  mv foo $file
done
```

I haven't tested it, because it's hard for me to test without the docker changes.
